### PR TITLE
Implement AsRawFd for PpsDevice

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@ use std::{
     io::{Error, Result},
     mem::MaybeUninit,
     os::{
-        fd::AsRawFd,
+        fd::{AsRawFd, RawFd},
         raw::{c_uint, c_ulong},
     },
     path::PathBuf,
@@ -96,5 +96,11 @@ impl PpsDevice {
             nsec: 0,
             flags: 0,
         })
+    }
+}
+
+impl AsRawFd for PpsDevice {
+    fn as_raw_fd(&self) -> RawFd {
+        self.0.as_raw_fd()
     }
 }


### PR DESCRIPTION
I want this to allow for more direct usage, more specifically I wanted to allow this usage:
```rust
use pps_time::PpsDevice;
use tokio::io::{Interest, unix::AsyncFd};

struct AsyncPps {
    inner: AsyncFd<PpsDevice>,
}

impl AsyncPps {
    fn new(pps: PpsDevice) -> std::io::Result<Self> {
        Ok(AsyncPps { inner: AsyncFd::new(pps)?, })
    }

    pub async fn wait(&self) -> std::io::Result<()> {
        let mut guard = self.inner.ready(Interest::READABLE).await?;
        guard.clear_ready();
        Ok(())
    }
}
```
I think this is nicer than to allow access to the underlying `File`.