### PR TITLE
Accept AsRef<Path> instead of PathBuf to mirror std

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@ use std::{
         fd::AsRawFd,
         raw::{c_uint, c_ulong},
     },
-    path::PathBuf,
+    path::Path,
 };
 
 pub mod pps;
@@ -21,7 +21,7 @@ const PPS_FETCH: c_ulong = 0xc00870a4;
 pub struct PpsDevice(File);
 
 impl PpsDevice {
-    pub fn new(path: PathBuf) -> Result<PpsDevice> {
+    pub fn new<P: AsRef<Path>>(path: P) -> Result<PpsDevice> {
         Ok(PpsDevice(File::open(path)?))
     }
 


### PR DESCRIPTION
This is a breaking change, but I think it will make the API nicer and more efficient since you no longer need to pass a owned string to the `new` method.

For reference the std library does it in the same way: https://doc.rust-lang.org/stable/std/fs/struct.File.html#method.open

This change will mean that you can do the following:
```rust
PpsDevice::new("/dev/pps0")?;
```